### PR TITLE
Fix visual details in image list, domain search and image details

### DIFF
--- a/viatimages/assets/javascripts/viatimages.js
+++ b/viatimages/assets/javascripts/viatimages.js
@@ -21,9 +21,11 @@ $(document).ready(function() {
     e.preventDefault()
     d = $('#caracteristiques').css('display');
     if (d == 'none') {
-      $('#arrowCaracteristiques').attr('src', '/assets/arrow-collapse.gif');
+      document.getElementById('arrowCaracteristiquesExpand').classList.add('hidden')
+      document.getElementById('arrowCaracteristiquesCollapse').classList.remove('hidden')
     } else {
-      $('#arrowCaracteristiques').attr('src', '/assets/arrow-expand.gif');
+      document.getElementById('arrowCaracteristiquesExpand').classList.remove('hidden')
+      document.getElementById('arrowCaracteristiquesCollapse').classList.add('hidden')
     }
     $('#caracteristiques').animate({height: 'toggle'});
   });
@@ -32,9 +34,11 @@ $(document).ready(function() {
     e.preventDefault()
     d = $('#remarques').css('display');
     if (d == 'none') {
-      $('#arrowRemarques').attr('src', '/assets/arrow-collapse.gif');
+      document.getElementById('arrowRemarquesExpand').classList.add('hidden')
+      document.getElementById('arrowRemarquesCollapse').classList.remove('hidden')
     } else {
-      $('#arrowRemarques').attr('src', '/assets/arrow-expand.gif');
+      document.getElementById('arrowRemarquesExpand').classList.remove('hidden')
+      document.getElementById('arrowRemarquesCollapse').classList.add('hidden')
     }
     $('#remarques').animate({height: 'toggle'});
   });

--- a/viatimages/assets/javascripts/viatimages.js
+++ b/viatimages/assets/javascripts/viatimages.js
@@ -28,15 +28,16 @@ $(document).ready(function() {
     $('#caracteristiques').animate({height: 'toggle'});
   });
 
-    $("a#remarquesLabel").click(function() {
-        d = $('#remarques').css('display');
-        if (d == 'none') {
-            $('#arrowRemarques').attr('src', '/assets/arrow-collapse.gif');
-        } else {
-            $('#arrowRemarques').attr('src', '/assets/arrow-expand.gif');
-        }
-        $('#remarques').animate({height: 'toggle'});
-    });
+  $("a#remarquesLabel").click(function(e) {
+    e.preventDefault()
+    d = $('#remarques').css('display');
+    if (d == 'none') {
+      $('#arrowRemarques').attr('src', '/assets/arrow-collapse.gif');
+    } else {
+      $('#arrowRemarques').attr('src', '/assets/arrow-expand.gif');
+    }
+    $('#remarques').animate({height: 'toggle'});
+  });
 
     $("a#texteImageLabel").click(function() {
         d = $('#texteImage').css('display');

--- a/viatimages/assets/stylesheets/_image.scss
+++ b/viatimages/assets/stylesheets/_image.scss
@@ -116,6 +116,9 @@
 #carte-content {
   margin-top: 10px;
 }
+.mots-cles {
+  color: #fff;
+}
 .mots-cles a {
   background-color: #ffffff;
   line-height: 27px;

--- a/viatimages/controllers/viatimages_items_controller.rb
+++ b/viatimages/controllers/viatimages_items_controller.rb
@@ -3,6 +3,13 @@ class ViatimagesItemsController < ItemsController
 
   def index
     super
+    
+    # Check if images are requested for a single domain
+    if @_request['domaine']
+      lang_domain = @_request['domaine']
+      @domain = lang_domain[3..]
+    end
+
     # If corpus id request parameter is available, send corresponding corpus item to view
     @corpus = Item.where(id: params['corpus']).first if params['corpus'].present?
   end

--- a/viatimages/locales/viat.de.yml
+++ b/viatimages/locales/viat.de.yml
@@ -37,6 +37,7 @@ de:
   items:
       index:
         images-for-book: "Bilder für das Werk"
+        images-for-domain: "Bilder für die Domäne"
       item_list_nav:
         back: "Zurück zu den Suchergebnissen"
         viat-images: "Bild %{current} von %{total}"

--- a/viatimages/locales/viat.en.yml
+++ b/viatimages/locales/viat.en.yml
@@ -37,6 +37,7 @@ en:
   items:
       index:
         images-for-book: "images for the book"
+        images-for-domain: "images for the domain"
       item_list_nav:
         back: "Back to the search results"
         viat-images: "Image %{current} of %{total}"

--- a/viatimages/locales/viat.fr.yml
+++ b/viatimages/locales/viat.fr.yml
@@ -37,6 +37,7 @@ fr:
   items:
       index:
         images-for-book: "images pour l'ouvrage"
+        images-for-domain: "images pour le domaine"
       item_list_nav:
         back: "Retour à la page de résultats"
         viat-images: "Image %{current} de %{total}"

--- a/viatimages/locales/viat.it.yml
+++ b/viatimages/locales/viat.it.yml
@@ -37,6 +37,7 @@ it:
   items:
       index:
         images-for-book: "immagini per il libro"
+        images-for-domain: "immagini per l'area"
       item_list_nav:
         back: "Torna ai risultati di ricerca"
         viat-images: "Immagine %{current} di %{total}"

--- a/viatimages/views/items/_thumbnails.html.erb
+++ b/viatimages/views/items/_thumbnails.html.erb
@@ -1,17 +1,21 @@
 <div class="row">
   <% item_list.items.each_with_index do |item, i| %>
     <% i += 1 %>
-    <% if i.modulo(4).zero? %><div class="row"><% end %>
-        <div class="col-md-3 col-xs-6">
-          <div class="thumbnail">
-            <%= item_list_link(item_list, item, i ) do %>
-              <%= item_thumbnail(item, :style => :medium) %>
-            <% end %>
-            <div class="caption">
-              <%= item_list_link(item_list, item, i, truncate(item_display_name(item), :length => 50)) %>
-            </div>
-          </div>
+    <div class="col-md-3 col-xs-6">
+      <div class="thumbnail">
+        <%= item_list_link(item_list, item, i ) do %>
+          <%= item_thumbnail(item, :style => :medium) %>
+        <% end %>
+        <div class="caption">
+          <%= item_list_link(item_list, item, i, truncate(item_display_name(item), :length => 50)) %>
         </div>
-    <% if i.modulo(4).zero? %></div><% end %>
+      </div>
+    </div>
+
+    <% if i.modulo(4).zero? %>
+      </div>
+      <div class="row">
+    <% end %>
+
   <% end %>
 </div>

--- a/viatimages/views/items/index.html.erb
+++ b/viatimages/views/items/index.html.erb
@@ -16,6 +16,15 @@
           </span>
         </div>
       <% end %>
+
+      <% if @domain.present? %>
+        <div id="ouvrage">
+          <span class="searchmsg">
+            <%= @browse.total_count %> <%= t(".images-for-domain") %>: <i>«<%= @domain %>»</i> 
+          </span>
+        </div>
+      <% end %>
+
       <%= render_item_list(@browse) %>
       <%= paginate(@browse.items) %>
     </div>

--- a/viatimages/views/items/type/_corpus.html.erb
+++ b/viatimages/views/items/type/_corpus.html.erb
@@ -1,14 +1,14 @@
 <div id="ouvrage">
-  <% if @title && strip_tags(field_value(@item, @title)).present? %>
-    <h2 id="titreOuvrage"><%= field_value(@item, @title) %></h2>
+  <% if @titre && strip_tags(field_value(@item, @titre)).present? %>
+    <h2 id="titreOuvrage"><%= field_value(@item, @titre) %></h2>
   <% end %>
 
   <% if @titre_trad && strip_tags(field_value(@item, @titre_trad)).present? %>
     <h2 id="titreOuvrageTrad"><%= field_value(@item, @titre_trad) %></h2>
   <% end %>
 
-  <% if @title_long && strip_tags(field_value(@item, @title_long)).present? %>
-    <h4 id="titreOuvrageLong"><%= field_value(@item, @title_long) %></h4>
+  <% if @titre_long && strip_tags(field_value(@item, @titre_long)).present? %>
+    <h4 id="titreOuvrageLong"><%= field_value(@item, @titre_long) %></h4>
   <% end %>
 
   <div id="corpus-persos">

--- a/viatimages/views/items/type/_image.html.erb
+++ b/viatimages/views/items/type/_image.html.erb
@@ -82,7 +82,9 @@
 
             <p class="info">
               <a id="caracteristiquesLabel" href="#">
-                <span><%= t(".viat-characteristics") %></span><%= image_tag("arrow-expand.gif", :id => "arrowCaracteristiques", :class => "info-toggle-img") %>
+                <span><%= t(".viat-characteristics") %></span>
+                <%= image_tag("arrow-expand.gif", :id => "arrowCaracteristiquesExpand", :class => "info-toggle-img") %>
+                <%= image_tag("arrow-collapse.gif", :id => "arrowCaracteristiquesCollapse", :class => "info-toggle-img hidden") %>
               </a>
             </p>
             <div id="caracteristiques">
@@ -158,7 +160,9 @@
               (@date_evenement && strip_tags(field_value(@item, @date_evenement)).present?) %>
               <p class="info">
                 <a id ="remarquesLabel" href="#">
-                  <span><%= t(".viat-comments") %></span><%= image_tag("arrow-expand.gif", :id => "arrowRemarques", :class => "info-toggle-img") %>
+                  <span><%= t(".viat-comments") %></span>
+                  <%= image_tag("arrow-expand.gif", :id => "arrowRemarquesExpand", :class => "info-toggle-img") %>
+                  <%= image_tag("arrow-collapse.gif", :id => "arrowRemarquesCollapse", :class => "info-toggle-img hidden") %>
                 </a>
               </p>
               <div id="remarques">


### PR DESCRIPTION
This PR fixes a few details in the Viatimages catalog override, especially the image list which was broken, the title for the domain search and corpus. It also contains some fixes for the image details.